### PR TITLE
feat: change disc image based on turn direction

### DIFF
--- a/iidxwidget-app/main.js
+++ b/iidxwidget-app/main.js
@@ -38,7 +38,8 @@ const defaultSettings = {
   widget: {
     infoPosition: "bottom",
     buttonLayout: "1P",
-    discImagePath: null,
+    upDiscImagePath: null,
+    downDiscImagePath: null,
     showPromoBox: false,
     GlobalReleaseMALength: 200,
     PerButtonMALength: 200,
@@ -292,7 +293,6 @@ ipcMain.handle('save-user-image', async (event, sourcePath) => {
     const ip = require('ip');
     const hostAddress = ip.address(); // 예: 192.168.0.13
     const publicUrl = `http://${hostAddress}:${settings.serverPort}/userImages/${fileName}`;
-    settings.widget.discImagePath = publicUrl;
     fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
 
     return publicUrl;  // ✅ 여기 수정!

--- a/iidxwidget-app/renderer/settings/settings.html
+++ b/iidxwidget-app/renderer/settings/settings.html
@@ -81,12 +81,20 @@
     </div>
     <label class="section-label">위젯 외관 커스터마이징</label>
     <div class="setting-group">
-      <label>스크래치 커스텀 이미지 업로드</label>
+      <label>기본 / 윗방향 스크래치 커스텀 이미지 업로드</label>
       <div class="input-with-delete">
-        <input type="file" id="disc-image-upload" accept="image/*">
-        <button id="delete-disc-button">삭제</button>
+        <input type="file" id="up-disc-image-upload" accept="image/*">
+        <button id="delete-up-disc-button">삭제</button>
       </div>
-      <img id="disc-preview" style="margin-top: 10px; max-width: 100%; border-radius: 10px;" />
+      <img id="up-disc-preview" style="margin-top: 10px; max-width: 100%; border-radius: 10px;" />
+    </div>
+    <div class="setting-group">
+      <label>아랫방향 스크래치 커스텀 이미지 업로드</label>
+      <div class="input-with-delete">
+        <input type="file" id="down-disc-image-upload" accept="image/*">
+        <button id="delete-down-disc-button">삭제</button>
+      </div>
+      <img id="down-disc-preview" style="margin-top: 10px; max-width: 100%; border-radius: 10px;" />
     </div>
     <div class="setting-group">
       <div class="color-setting-row">

--- a/iidxwidget-app/renderer/settings/settings.js
+++ b/iidxwidget-app/renderer/settings/settings.js
@@ -1,5 +1,5 @@
-let uploadedDiscImagePath = null;
-let removeDiscImage = false;
+let uploadedUpDiscImagePath = null;
+let uploadedDownDiscImagePath = null;
 
 document.getElementById('cancel-button').addEventListener('click', () => {
   window.close();
@@ -56,7 +56,8 @@ document.getElementById('save-button').addEventListener('click', async () => {
     widget: {
       infoPosition,
       buttonLayout,
-      discImagePath: uploadedDiscImagePath,
+      upDiscImagePath: uploadedUpDiscImagePath,
+      downDiscImagePath: uploadedDownDiscImagePath,
       showPromoBox,
       globalMALength,
       perButtonMALength,
@@ -125,13 +126,19 @@ function toggleKeyMappingUI(profile) {
     document.getElementById('color-fontColor').value = mergedColors.fontColor;
     document.getElementById('color-activeColor').value = mergedColors.activeColor;
 
-    uploadedDiscImagePath = settings.widget?.discImagePath || null;
-    removeDiscImage = false;
+    uploadedUpDiscImagePath = settings.widget?.upDiscImagePath || null;
+    uploadedDownDiscImagePath = settings.widget?.downDiscImagePath || null;
 
-    if (uploadedDiscImagePath) {
-      const previewImg = document.getElementById('disc-preview');
-      previewImg.src = uploadedDiscImagePath;
-      previewImg.style.display = 'block';
+    if (uploadedUpDiscImagePath) {
+      const upDiscPreviewImg = document.getElementById('up-disc-preview');
+      upDiscPreviewImg.src = uploadedUpDiscImagePath;
+      upDiscPreviewImg.style.display = 'block';
+    }
+
+    if (uploadedDownDiscImagePath) {
+      const downDiscPreviewImg = document.getElementById('down-disc-preview');
+      downDiscPreviewImg.src = uploadedDownDiscImagePath;
+      downDiscPreviewImg.style.display = 'block';
     }
 
     bindColorPreview('color-background', 'preview-background');
@@ -167,7 +174,7 @@ document.querySelectorAll('#key-mapping-table input').forEach(input => {
   });
 });
 
-document.getElementById('disc-image-upload').addEventListener('change', async (e) => {
+document.getElementById('up-disc-image-upload').addEventListener('change', async (e) => {
   const file = e.target.files[0];
   if (!file) return;
 
@@ -175,26 +182,52 @@ document.getElementById('disc-image-upload').addEventListener('change', async (e
   const savedPath = await window.electronAPI.saveUserImage(filePath);
 
   if (savedPath) {
-    uploadedDiscImagePath = savedPath;
-    removeDiscImage = false;
+    uploadedUpDiscImagePath = savedPath;
 
-    const previewImg = document.getElementById('disc-preview');
+    const previewImg = document.getElementById('up-disc-preview');
     previewImg.src = savedPath;
     previewImg.style.display = 'block';
   }
 });
 
-document.getElementById('delete-disc-button').addEventListener('click', () => {
-  uploadedDiscImagePath = null;
-  removeDiscImage = true;
+document.getElementById('delete-up-disc-button').addEventListener('click', () => {
+  uploadedUpDiscImagePath = null;
 
-  const previewImg = document.getElementById('disc-preview');
+  const previewImg = document.getElementById('up-disc-preview');
   previewImg.src = '';
   previewImg.style.display = 'none';
 
   // 파일 선택 input 초기화
-  document.getElementById('disc-image-upload').value = '';
+  document.getElementById('up-disc-image-upload').value = '';
 });
+
+document.getElementById('down-disc-image-upload').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  const filePath = file.path;
+  const savedPath = await window.electronAPI.saveUserImage(filePath);
+
+  if (savedPath) {
+    uploadedDownDiscImagePath = savedPath;
+
+    const previewImg = document.getElementById('down-disc-preview');
+    previewImg.src = savedPath;
+    previewImg.style.display = 'block';
+  }
+});
+
+document.getElementById('delete-down-disc-button').addEventListener('click', () => {
+  uploadedDownDiscImagePath = null;
+
+  const previewImg = document.getElementById('down-disc-preview');
+  previewImg.src = '';
+  previewImg.style.display = 'none';
+
+  // 파일 선택 input 초기화
+  document.getElementById('down-disc-image-upload').value = '';
+});
+
 
 function bindColorPreview(inputId, previewId) {
   const input = document.getElementById(inputId);

--- a/iidxwidget-app/renderer/widget/index.html
+++ b/iidxwidget-app/renderer/widget/index.html
@@ -18,7 +18,8 @@
           <div id="lower-indicator" class="ring-half"></div>
         </div>
         <div id="disc">
-          <img id="disc-image" src="" alt=" " />
+          <img id="up-disc-image" class="disc-image" src="" alt=" " />
+          <img id="down-disc-image" class="disc-image" src="" alt=" " />
           <div id="disc-needle"></div>
         </div>
       </div>

--- a/iidxwidget-app/renderer/widget/index.js
+++ b/iidxwidget-app/renderer/widget/index.js
@@ -15,6 +15,10 @@ let keyTimestamps = [];
 let globalMALength = 200;
 let perButtonMALength = 200;
 
+let upDiscImagePath = null;
+let downDiscImagePath = null;
+let isLatestDiscDirectionUp = false;
+
 const disc = document.getElementById("disc");
 const upperIndicator = document.getElementById("upper-indicator");
 const lowerIndicator = document.getElementById("lower-indicator");
@@ -39,7 +43,12 @@ function startUptimeTimer() {
 function rotateDisc(delta) {
   discRotation -= delta * 2.5;
   disc.style.transform = `translate(-50%, -50%) rotate(${discRotation}deg)`;
-  updateBorders(delta);
+}
+
+function changeDiscImage(delta) {
+  if (delta === 0) return;
+  if (is2PMode) delta = -delta;
+  applyDiscImage(delta > 0);
 }
 
 function updateBorders(delta) {
@@ -116,20 +125,29 @@ function updateKPSDisplay() {
 }
 setInterval(updateKPSDisplay, 100);
 
-function applyDiscImage(imagePath) {
+function applyDiscImage(isUp) {
   const img = document.getElementById('disc-image');
   const needle = document.getElementById('disc-needle');
 
   if (!img || !needle) return;
+  if (isUp == isLatestDiscDirectionUp) return;
 
-  if (!imagePath) {
-    img.src = '';
-    img.style.display = 'none';
-    needle.style.display = 'block';  // 기본 bar 보이기
-  } else {
-    img.src = imagePath;
+  if (isUp) {
+    if (!upDiscImagePath) {
+      img.src = '';
+      img.style.display = 'none';
+      needle.style.display = 'block';  // 기본 bar 보이기
+    } else {
+      img.src = upDiscImagePath;
+      img.style.display = 'block';
+      needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
+    }
+    isLatestDiscDirectionUp = true;
+  } else if (downDiscImagePath) {
+    img.src = downDiscImagePath;
     img.style.display = 'block';
     needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
+    isLatestDiscDirectionUp = false;
   }
 }
 
@@ -142,6 +160,7 @@ function handleData(data) {
         let delta = (newValue - lastDiscValue + 256) % 256;
         if (delta > 127) delta -= 256;
         rotateDisc(delta);
+        changeDiscImage(delta);
         updateBorders(delta);
       }
       lastDiscValue = newValue;
@@ -208,7 +227,9 @@ function applyButtonLayout(layout) {
   if (settings?.widget) {
     applyReleaseContainerSettings(settings.widget.infoPosition || 'bottom');
     applyButtonLayout(settings.widget.buttonLayout || '1P');
-    applyDiscImage(settings?.widget?.discImagePath);
+    upDiscImagePath = settings.widget.upDiscImagePath;
+    downDiscImagePath = settings.widget.downDiscImagePath;
+    applyDiscImage(true);
     applyPromoBox(settings);
     globalMALength = settings.widget.globalMALength || 200;
     perButtonMALength = settings.widget.perButtonMALength || 200;

--- a/iidxwidget-app/renderer/widget/index.js
+++ b/iidxwidget-app/renderer/widget/index.js
@@ -15,11 +15,12 @@ let keyTimestamps = [];
 let globalMALength = 200;
 let perButtonMALength = 200;
 
-let upDiscImagePath = null;
-let downDiscImagePath = null;
-let isLatestDiscDirectionUp = false;
+let isLatestDiscDirectionUp = true;
 
 const disc = document.getElementById("disc");
+const upImg = document.getElementById('up-disc-image');
+const downImg = document.getElementById('down-disc-image');
+const needle = document.getElementById('disc-needle');
 const upperIndicator = document.getElementById("upper-indicator");
 const lowerIndicator = document.getElementById("lower-indicator");
 
@@ -48,7 +49,28 @@ function rotateDisc(delta) {
 function changeDiscImage(delta) {
   if (delta === 0) return;
   if (is2PMode) delta = -delta;
-  applyDiscImage(delta > 0);
+
+  const isUp = delta > 0;
+  if (isLatestDiscDirectionUp == isUp) return;
+
+  if (isUp) {
+    downImg.style.display = 'none';
+    if (upImg.classList.contains("img-available")) {
+      upImg.style.display = 'block';
+      needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
+    } else {
+      upImg.style.display = 'none';
+      needle.style.display = 'block';  // 기본 bar 보이기
+    }
+    isLatestDiscDirectionUp = true;
+  } else { // Is down
+    if (downImg.classList.contains("img-available")) {
+      upImg.style.display = 'none'; // Remove the upDisc image only if the downDisc image is available
+      downImg.style.display = 'block';
+      needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
+      isLatestDiscDirectionUp = false;
+    }
+  }
 }
 
 function updateBorders(delta) {
@@ -125,29 +147,28 @@ function updateKPSDisplay() {
 }
 setInterval(updateKPSDisplay, 100);
 
-function applyDiscImage(isUp) {
-  const img = document.getElementById('disc-image');
-  const needle = document.getElementById('disc-needle');
-
-  if (!img || !needle) return;
-  if (isUp == isLatestDiscDirectionUp) return;
-
-  if (isUp) {
-    if (!upDiscImagePath) {
-      img.src = '';
-      img.style.display = 'none';
-      needle.style.display = 'block';  // 기본 bar 보이기
-    } else {
-      img.src = upDiscImagePath;
-      img.style.display = 'block';
-      needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
-    }
-    isLatestDiscDirectionUp = true;
-  } else if (downDiscImagePath) {
-    img.src = downDiscImagePath;
-    img.style.display = 'block';
+function applyDiscImage(settings) {
+  let upDiscImagePath = settings.widget.upDiscImagePath;
+  let downDiscImagePath = settings.widget.downDiscImagePath;
+  
+  if (upDiscImagePath) {
+    upImg.classList.add("img-available");
+    upImg.src = upDiscImagePath;
+    upImg.style.display = 'block';
     needle.style.display = 'none';   // 이미지 있으면 bar 숨기기
-    isLatestDiscDirectionUp = false;
+  } else {
+    upImg.classList.remove("img-available");
+    upImg.src = '';
+    upImg.style.display = 'none';
+    needle.style.display = 'block';  // 기본 bar 보이기
+  }
+
+  if (downDiscImagePath) {
+    downImg.classList.add("img-available");
+    downImg.src = downDiscImagePath;
+    downImg.style.display = 'none';
+  } else {
+    downImg.classList.remove("img-available");
   }
 }
 
@@ -227,9 +248,7 @@ function applyButtonLayout(layout) {
   if (settings?.widget) {
     applyReleaseContainerSettings(settings.widget.infoPosition || 'bottom');
     applyButtonLayout(settings.widget.buttonLayout || '1P');
-    upDiscImagePath = settings.widget.upDiscImagePath;
-    downDiscImagePath = settings.widget.downDiscImagePath;
-    applyDiscImage(true);
+    applyDiscImage(settings);
     applyPromoBox(settings);
     globalMALength = settings.widget.globalMALength || 200;
     perButtonMALength = settings.widget.perButtonMALength || 200;

--- a/iidxwidget-app/renderer/widget/style.css
+++ b/iidxwidget-app/renderer/widget/style.css
@@ -87,7 +87,7 @@ body {
   border-radius: 3px;
 }
 
-#disc-image {
+.disc-image {
   width: 100%;
   height: 100%;
   object-fit: cover;     /* 정사각형 채움 */


### PR DESCRIPTION
스크래치 회전 방향에 따라 이미지가 바뀌는 기능입니다.
두 개의 image 요소를 생성하고, 회전 방향에 따라 display 속성을 변경하는 방식으로 제작했습니다.
(처음에는 회전 방향에 따라 image 요소의 src 속성을 매번 변경하는 로직으로 제작했지만, 매번 이미지를 불러오면 투컴 환경에서 문제가 생길 수 있을 것 같아 로직을 변경하였습니다.)

설정에서 '기본 및 윗방향 회전 시 표시되는 이미지' / '아랫방향 회전 시 표시되는 이미지'의 설정 여부에 따라 로직이 약간 달라집니다.
|이미지 여부|윗방향 O|윗방향 X|
|---|---|---|
|아랫방향 O|https://github.com/user-attachments/assets/a45c327c-960b-4a20-a4cb-c161d6c90628|https://github.com/user-attachments/assets/c9b6e64a-f4dd-44b8-96c7-a93d677a609a|
|아랫방향 X|https://github.com/user-attachments/assets/309dd96a-eedd-4e04-be65-f469a57b6589|https://github.com/user-attachments/assets/ca8f0387-92d7-4a85-baa7-43e7e8e7c81b|

이미지 설정 여부에 따른 로직이 사용자 입장에서는 다소 이해하기 힘들 수 있겠다고 생각합니다.
또한, settings.json의 discImagePath 키 이름이 변경되어, 구버전에서 설정한 이미지를 불러오지 못할 것으로 예상됩니다.

큰 의미가 있는 기능은 아니라고 생각합니다만, 제작한 김에 pr을 신청합니다.

테스트는 원컴 + PHOENIXWAN LR2 모드, 그리고 원컴 + PHOENIXWAN 인피니타스 모드에서 진행했습니다.